### PR TITLE
Implement `GET /claims`

### DIFF
--- a/apps/api-v2/src/app.module.ts
+++ b/apps/api-v2/src/app.module.ts
@@ -7,14 +7,16 @@ import { ApplicationsModule } from "./sections/applications/applications.module"
 import { AuthModule } from "./sections/auth/auth.module";
 import { StatusModule } from "./sections/status/status.module";
 import { UtilityModule } from "./sections/utility/utility.module";
+import { ClaimsModule } from "./sections/claims/claims.module";
 
 @Module({
   imports: [
-    UtilityModule,
-    AuthModule,
     ApplicationsModule,
-    StatusModule,
+    AuthModule,
+    ClaimsModule,
     ConfigModule.forRoot({ isGlobal: true, cache: true }),
+    StatusModule,
+    UtilityModule,
   ],
   providers: [PrismaService, { provide: APP_GUARD, useClass: AuthGuard }],
 })

--- a/apps/api-v2/src/common/db/external/cachet.service.ts
+++ b/apps/api-v2/src/common/db/external/cachet.service.ts
@@ -9,8 +9,8 @@ import { firstValueFrom } from "rxjs";
 @Injectable()
 export class CachetAPIService {
   private readonly logger = new Logger(CachetAPIService.name);
-  private baseURL: string;
-  private apiToken: string;
+  private baseURL: string | undefined;
+  private apiToken: string | undefined;
 
   constructor(
     private readonly http: HttpService,
@@ -26,11 +26,11 @@ export class CachetAPIService {
     } else {
       this.baseURL = this.configService.get<string>("CACHET_URL") as string;
       this.apiToken = this.configService.get<string>("CACHET_TOKEN") as string;
-    }
 
-    this.testConnection().then(() => {
-      this.logger.log("Cachet API is reachable");
-    });
+      this.testConnection().then(() => {
+        this.logger.log("Cachet API is reachable");
+      });
+    }
   }
 
   async testConnection(): Promise<string> {

--- a/apps/api-v2/src/common/decorators/api-response.decorator.ts
+++ b/apps/api-v2/src/common/decorators/api-response.decorator.ts
@@ -18,7 +18,7 @@ import { ResponseDto } from "../dto/response.dto";
  */
 export function ApiDefaultResponse<TModel extends Type<any>>(
   model: TModel,
-  options: ApiResponseOptions = {},
+  { isArray, ...options }: ApiResponseOptions & { isArray?: boolean } = {},
 ) {
   return applyDecorators(
     ApiExtraModels(ResponseDto, model),
@@ -30,7 +30,9 @@ export function ApiDefaultResponse<TModel extends Type<any>>(
           { $ref: getSchemaPath(ResponseDto) },
           {
             properties: {
-              data: { $ref: getSchemaPath(model) },
+              data: isArray
+                ? { type: "array", items: { $ref: getSchemaPath(model) } }
+                : { $ref: getSchemaPath(model) },
             },
           },
         ],

--- a/apps/api-v2/src/common/decorators/optional-auth.decorator.ts
+++ b/apps/api-v2/src/common/decorators/optional-auth.decorator.ts
@@ -1,0 +1,18 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const IS_AUTH_OPTIONAL_KEY = "isAuthOptional";
+
+/**
+ * Decorator that makes authentication optional for a route. By default, routes
+ * require a valid JWT token.
+ *
+ * @example
+ *
+ * @OptionalAuth()
+ * @Get('optional-auth-endpoint')
+ * async getOptionalAuthData(@Request() req: Request) {
+ *   // req.token may be undefined if no valid token is provided
+ * }
+ *
+ */
+export const OptionalAuth = () => SetMetadata(IS_AUTH_OPTIONAL_KEY, true);

--- a/apps/api-v2/src/common/guards/auth.guard.ts
+++ b/apps/api-v2/src/common/guards/auth.guard.ts
@@ -8,6 +8,7 @@ import { Reflector } from "@nestjs/core";
 import { JwtService } from "@nestjs/jwt";
 import { Request } from "express";
 import { IS_PUBLIC_KEY } from "../decorators/skip-auth.decorator";
+import { IS_AUTH_OPTIONAL_KEY } from "../decorators/optional-auth.decorator";
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(
@@ -31,16 +32,28 @@ export class AuthGuard implements CanActivate {
       return true;
     }
 
+    const isOptional = this.reflector.getAllAndOverride<boolean>(
+      IS_AUTH_OPTIONAL_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
     // If the route is not public, we proceed with authentication
     const request = context.switchToHttp().getRequest<Request>();
     const token = this.extractTokenFromHeader(request);
+
+    if (!token && isOptional) {
+      return true;
+    }
+
     if (!token) {
       throw new UnauthorizedException();
     }
+
     try {
       const payload = await this.jwtService.verifyAsync(token);
       request["token"] = payload;
     } catch {
+      // If auth is optional but failed to verify, we still reject the request
       throw new UnauthorizedException();
     }
     return true;

--- a/apps/api-v2/src/sections/auth/auth.module.ts
+++ b/apps/api-v2/src/sections/auth/auth.module.ts
@@ -14,7 +14,7 @@ import { AuthService } from "./auth.service";
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>("JWT_SECRET"),
+        secret: configService.getOrThrow<string>("JWT_SECRET"),
         signOptions: { issuer: "api" },
       }),
     }),

--- a/apps/api-v2/src/sections/claims/claims.controller.ts
+++ b/apps/api-v2/src/sections/claims/claims.controller.ts
@@ -3,10 +3,15 @@ import { ClaimsService } from "./claims.service";
 import { Filtered } from "src/common/decorators/filtered.decorator";
 import { ApiBearerAuth, ApiOperation } from "@nestjs/swagger";
 import { ClaimDto } from "./dto/claim.dto";
-import { ApiDefaultResponse } from "src/common/decorators/api-response.decorator";
+import { ApiPaginatedResponseDto } from "src/common/decorators/api-response.decorator";
 import { Filter, FilterParams } from "src/common/decorators/filter.decorator";
 import { Request } from "express";
 import { OptionalAuth } from "src/common/decorators/optional-auth.decorator";
+import {
+  Pagination,
+  PaginationParams,
+} from "src/common/decorators/pagination.decorator";
+import { Paginated } from "src/common/decorators/paginated.decorator";
 
 @Controller("claims")
 export class ClaimsController {
@@ -15,6 +20,7 @@ export class ClaimsController {
   @Get()
   @OptionalAuth()
   @ApiBearerAuth()
+  @Paginated()
   @ApiOperation({
     summary: "Get All Claims",
     description:
@@ -28,11 +34,12 @@ export class ClaimsController {
       { name: "slug", required: false, type: Boolean },
     ],
   })
-  @ApiDefaultResponse(ClaimDto, {
-    description: "List of claims matching the filters.",
-    isArray: true,
-  })
-  findAll(@Filter() filter: FilterParams, @Req() req: Request) {
+  @ApiPaginatedResponseDto(ClaimDto, { description: "Success" })
+  findAll(
+    @Pagination() pagination: PaginationParams,
+    @Filter() filter: FilterParams,
+    @Req() req: Request,
+  ) {
     const { team, slug, ...otherFilters }: { team?: string; slug?: boolean } =
       filter.filter;
 
@@ -46,6 +53,9 @@ export class ClaimsController {
       return { buildTeamId: team };
     })();
 
-    return this.claimsService.findAll({ ...otherFilters, ...teamFilter });
+    return this.claimsService.findAll(pagination, {
+      ...otherFilters,
+      ...teamFilter,
+    });
   }
 }

--- a/apps/api-v2/src/sections/claims/claims.controller.ts
+++ b/apps/api-v2/src/sections/claims/claims.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { ClaimsService } from "./claims.service";
+import { Filtered } from "src/common/decorators/filtered.decorator";
+import { ApiOperation, ApiQuery } from "@nestjs/swagger";
+import { ClaimDto } from "./dto/claim.dto";
+import { ApiDefaultResponse } from "src/common/decorators/api-response.decorator";
+import { Filter, FilterParams } from "src/common/decorators/filter.decorator";
+
+@Controller("claims")
+export class ClaimsController {
+  constructor(private readonly claimsService: ClaimsService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: "Get All Claims",
+    description: "Returns all claims based on provided filters.",
+  })
+  @Filtered({
+    fields: [
+      { name: "finished", required: false, type: Boolean },
+      { name: "active", required: false, type: Boolean },
+      { name: "team", required: false, type: String },
+    ],
+  })
+  @ApiQuery({
+    name: "slug",
+    required: false,
+    type: Boolean,
+    description: "When true, team filters by slug, otherwise it filters by ID",
+  })
+  @ApiDefaultResponse(ClaimDto, {
+    description: "List of claims matching the filters.",
+    isArray: true,
+  })
+  findAll(@Filter() filter: FilterParams, @Query("slug") slug?: boolean) {
+    const { team, ...otherFilters }: { team?: string } = filter.filter;
+    const teamFilter = (() => {
+      if (!team) return {};
+      if (slug) return { buildTeam: { slug: team } };
+      return { buildTeamId: team };
+    })();
+
+    return this.claimsService.findAll({ ...otherFilters, ...teamFilter });
+  }
+}

--- a/apps/api-v2/src/sections/claims/claims.controller.ts
+++ b/apps/api-v2/src/sections/claims/claims.controller.ts
@@ -1,40 +1,46 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Req } from "@nestjs/common";
 import { ClaimsService } from "./claims.service";
 import { Filtered } from "src/common/decorators/filtered.decorator";
-import { ApiOperation, ApiQuery } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOperation } from "@nestjs/swagger";
 import { ClaimDto } from "./dto/claim.dto";
 import { ApiDefaultResponse } from "src/common/decorators/api-response.decorator";
 import { Filter, FilterParams } from "src/common/decorators/filter.decorator";
+import { Request } from "express";
+import { OptionalAuth } from "src/common/decorators/optional-auth.decorator";
 
 @Controller("claims")
 export class ClaimsController {
   constructor(private readonly claimsService: ClaimsService) {}
 
   @Get()
+  @OptionalAuth()
+  @ApiBearerAuth()
   @ApiOperation({
     summary: "Get All Claims",
-    description: "Returns all claims based on provided filters.",
+    description:
+      "Returns all claims for the given team. If no team is specified, returns claims for the authenticated team.",
   })
   @Filtered({
     fields: [
       { name: "finished", required: false, type: Boolean },
       { name: "active", required: false, type: Boolean },
       { name: "team", required: false, type: String },
+      { name: "slug", required: false, type: Boolean },
     ],
-  })
-  @ApiQuery({
-    name: "slug",
-    required: false,
-    type: Boolean,
-    description: "When true, team filters by slug, otherwise it filters by ID",
   })
   @ApiDefaultResponse(ClaimDto, {
     description: "List of claims matching the filters.",
     isArray: true,
   })
-  findAll(@Filter() filter: FilterParams, @Query("slug") slug?: boolean) {
-    const { team, ...otherFilters }: { team?: string } = filter.filter;
-    const teamFilter = (() => {
+  findAll(@Filter() filter: FilterParams, @Req() req: Request) {
+    const { team, slug, ...otherFilters }: { team?: string; slug?: boolean } =
+      filter.filter;
+
+    const teamFilter: {
+      buildTeamId?: string;
+      buildTeam?: { slug: string };
+    } = (() => {
+      if (!team && req.token) return { buildTeamId: req.token.id };
       if (!team) return {};
       if (slug) return { buildTeam: { slug: team } };
       return { buildTeamId: team };

--- a/apps/api-v2/src/sections/claims/claims.module.ts
+++ b/apps/api-v2/src/sections/claims/claims.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ClaimsService } from './claims.service';
+import { ClaimsController } from './claims.controller';
+
+@Module({
+  controllers: [ClaimsController],
+  providers: [ClaimsService],
+})
+export class ClaimsModule {}

--- a/apps/api-v2/src/sections/claims/claims.module.ts
+++ b/apps/api-v2/src/sections/claims/claims.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
-import { ClaimsService } from './claims.service';
-import { ClaimsController } from './claims.controller';
+import { Module } from "@nestjs/common";
+import { PrismaService } from "src/common/db/prisma.service";
+import { ClaimsController } from "./claims.controller";
+import { ClaimsService } from "./claims.service";
 
 @Module({
   controllers: [ClaimsController],
-  providers: [ClaimsService],
+  providers: [ClaimsService, PrismaService],
 })
 export class ClaimsModule {}

--- a/apps/api-v2/src/sections/claims/claims.service.ts
+++ b/apps/api-v2/src/sections/claims/claims.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from "@nestjs/common";
+import { FilterParams } from "src/common/decorators/filter.decorator";
+import { PrismaService } from "src/common/db/prisma.service";
+
+@Injectable()
+export class ClaimsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(filter: FilterParams["filter"]) {
+    return this.prisma.claim.findMany({
+      where: filter,
+      include: {
+        _count: { select: { builders: true, images: true } },
+        images: { select: { id: true, name: true, hash: true } },
+      },
+    });
+  }
+}

--- a/apps/api-v2/src/sections/claims/claims.service.ts
+++ b/apps/api-v2/src/sections/claims/claims.service.ts
@@ -1,18 +1,38 @@
 import { Injectable } from "@nestjs/common";
 import { FilterParams } from "src/common/decorators/filter.decorator";
 import { PrismaService } from "src/common/db/prisma.service";
+import { PaginationParams } from "src/common/decorators/pagination.decorator";
 
 @Injectable()
 export class ClaimsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll(filter: FilterParams["filter"]) {
-    return this.prisma.claim.findMany({
-      where: filter,
-      include: {
-        _count: { select: { builders: true, images: true } },
-        images: { select: { id: true, name: true, hash: true } },
+  async findAll(pagination: PaginationParams, filter: FilterParams["filter"]) {
+    const limit = Math.max(Number(pagination.limit) || 20, 1);
+    const page = Math.max(Number(pagination.page) || 1, 1);
+    const skip = (page - 1) * limit;
+
+    const [claims, total] = await Promise.all([
+      this.prisma.claim.findMany({
+        where: filter,
+        skip,
+        take: limit,
+        include: {
+          _count: { select: { builders: true, images: true } },
+          images: { select: { id: true, name: true, hash: true } },
+        },
+      }),
+      this.prisma.claim.count({ where: filter }),
+    ]);
+
+    return {
+      data: claims,
+      meta: {
+        page,
+        perPage: limit,
+        totalItems: total,
+        totalPages: Math.ceil(total / limit),
       },
-    });
+    };
   }
 }

--- a/apps/api-v2/src/sections/claims/dto/claim.dto.ts
+++ b/apps/api-v2/src/sections/claims/dto/claim.dto.ts
@@ -1,0 +1,28 @@
+export class ClaimDto {
+  id: string;
+  ownerId: string | null;
+  area: string[];
+  center: string | null;
+  size: number;
+  active: boolean;
+  finished: boolean;
+  buildTeamId: string;
+  name: string;
+  createdAt: string;
+  externalId: string | null;
+  description: string | null;
+  buildings: number;
+  city: string | null;
+  osmName: string | null;
+
+  _count: {
+    builders: number;
+    images: number;
+  };
+
+  images: {
+    id: string;
+    name: string;
+    hash: string;
+  }[];
+}


### PR DESCRIPTION
This PR implements `GET /claims`, with some other minor changes.

Want to confirm how auth should work for this route, it looks like v1 didn't check auth for this route, although v2 requires build team token auth by default.